### PR TITLE
fix(componentheader): fix stage null check for component header when …

### DIFF
--- a/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
+++ b/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
@@ -33,7 +33,7 @@ export const ComponentHeader: React.FC<ComponentHeaderProps> = ({
     <div className={styles.component}>
       <Title>{name}</Title>
       <div className={styles.version}>{version}</div>
-      {stage && <Status stage={stage} />}
+      {stage != null && stage !== undefined && <Status stage={stage} />}
       <div className={styles.links}>
         <div className={styles.github}>
           <a href={githubLink} target="_blank">

--- a/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
+++ b/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
@@ -33,7 +33,7 @@ export const ComponentHeader: React.FC<ComponentHeaderProps> = ({
     <div className={styles.component}>
       <Title>{name}</Title>
       <div className={styles.version}>{version}</div>
-      {stage != null && stage !== undefined && <Status stage={stage} />}
+      {Number.isInteger(stage) && <Status stage={stage} />}
       <div className={styles.links}>
         <div className={styles.github}>
           <a href={githubLink} target="_blank">

--- a/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
+++ b/.storybook/blocks/ComponentHeader/ComponentHeader.tsx
@@ -8,20 +8,16 @@ import styles from './ComponentHeader.module.css';
 type ComponentHeaderProps = {
   name: string;
   version?: string;
-  npmPackage?: string;
   stage: number;
   status?: string;
   design?: string;
-  children?: ReactNode;
 };
 
 export const ComponentHeader: React.FC<ComponentHeaderProps> = ({
   name,
   version,
-  npmPackage,
   stage,
   design,
-  children,
 }) => {
   const packageName = name
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')


### PR DESCRIPTION
…status component is used

Fix stage null check for component header when status component is used

## Pull Request

### Description

- When we set 0 for stage in ComponentHeader, status seems as 0

<img width="246" alt="Screenshot 2022-09-02 at 09 09 33" src="https://user-images.githubusercontent.com/1616251/188436065-6fe564c3-3069-4f90-ab5b-95bed86d9d98.png">

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:screenshots` - to run snapshot tests

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
