### PR TITLE
refactor: button documentation update [#HEYUI-179]

### DIFF
--- a/packages/button/src/docs/Component.stories.mdx
+++ b/packages/button/src/docs/Component.stories.mdx
@@ -28,6 +28,16 @@ import variantStyles from '!!raw-loader!../styles/variant.module.css';
         disable: true,
       },
     },
+    leftIcon: {
+      table: {
+        disable: true,
+      },
+    },
+    rightIcon: {
+      table: {
+        disable: true,
+      },
+    },
   }}
 />
 

--- a/packages/button/src/docs/Component.stories.mdx
+++ b/packages/button/src/docs/Component.stories.mdx
@@ -28,16 +28,6 @@ import variantStyles from '!!raw-loader!../styles/variant.module.css';
         disable: true,
       },
     },
-    leftIcon: {
-      table: {
-        disable: true,
-      },
-    },
-    rightIcon: {
-      table: {
-        disable: true,
-      },
-    },
   }}
 />
 

--- a/packages/button/src/docs/Description.mdx
+++ b/packages/button/src/docs/Description.mdx
@@ -1,5 +1,5 @@
 import { Container, Row, Col } from 'storybook/blocks';
-import { Whatsapp, Car } from '../../../icons/src';
+import { Whatsapp, Call } from '../../../icons/src';
 import Button from '../Button';
 
 ## Variants
@@ -112,18 +112,18 @@ render(
   <Container>
     <Row>
       <Col key="left">
-          <Button leftIcon={<Image />} color="primary">
+          <Button leftIcon={<Call />} color="primary">
             Button CTA
           </Button>
       </Col>
       <Col key="right">
-        <Button rightIcon={<Car />} color="primary">
+        <Button rightIcon={<Call />} color="primary">
           Button CTA
         </Button>
       </Col>
       {buttonSizes.map(size => (
         <Col key={size}>
-          <Button leftIcon={<Car />} rightIcon={<Car />} color="primary" size={size}>
+          <Button leftIcon={<Call />} rightIcon={<Call />} color="primary" size={size}>
             Button CTA
           </Button>
         </Col>
@@ -140,7 +140,7 @@ render(
     </Row>
     <Row>
       <Col>
-        <Button leftIcon={<Car />} color="primary" size="large"/>
+        <Button leftIcon={<Call />} color="primary" size="large"/>
       </Col>
     </Row>
   </Container>,

--- a/packages/button/src/docs/Description.mdx
+++ b/packages/button/src/docs/Description.mdx
@@ -1,5 +1,5 @@
 import { Container, Row, Col } from 'storybook/blocks';
-import { Whatsapp } from '../../../icons/src';
+import { Whatsapp, Car } from '../../../icons/src';
 import Button from '../Button';
 
 ## Variants
@@ -111,9 +111,19 @@ const buttonSizes = ['large', 'small'];
 render(
   <Container>
     <Row>
+      <Col key="left">
+          <Button leftIcon={<Image />} color="primary">
+            Button CTA
+          </Button>
+      </Col>
+      <Col key="right">
+        <Button rightIcon={<Car />} color="primary">
+          Button CTA
+        </Button>
+      </Col>
       {buttonSizes.map(size => (
         <Col key={size}>
-          <Button rightIcon="🚗" color="primary" size={size}>
+          <Button leftIcon={<Car />} rightIcon={<Car />} color="primary" size={size}>
             Button CTA
           </Button>
         </Col>
@@ -130,9 +140,7 @@ render(
     </Row>
     <Row>
       <Col>
-        <Button color="primary" size="large">
-          🚗
-        </Button>
+        <Button leftIcon={<Car />} color="primary" size="large"/>
       </Col>
     </Row>
   </Container>,


### PR DESCRIPTION
- [ ] Updating the Button documentation with Icons added to left and right

The current Button documentation doesn't show icons added to the left and right to the Button label.

**Current version**
<img width="1063" alt="Screenshot 2022-09-27 at 17 36 33" src="https://user-images.githubusercontent.com/113981728/192571233-0da5e612-2098-4ed1-ba7c-8ae1cbd787bf.png">

## Pull Request

### Description

**Updated version**

Updating  documentation showing icons added to left and right to the button label.
<img width="1030" alt="Screenshot 2022-09-27 at 17 27 41" src="https://user-images.githubusercontent.com/113981728/192569208-5a1a0fc3-0aae-4d71-9caf-6e6bdc39ca16.png">

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [x] `npm i` – for new NPM dependencies.
- [x] `npm run lint` - to check for linting issues
- [x] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
