### PR TITLE
feat(tabs): add focus state on tabs in storybook

### DIFF
--- a/.storybook/blocks/TabContainer/TabContainer.tsx
+++ b/.storybook/blocks/TabContainer/TabContainer.tsx
@@ -5,7 +5,6 @@ import cn from 'classnames';
 
 import styles from './TabContainer.module.css';
 
-
 export const TabContainer: React.FC<TabContainerProps> = ({ tabs }) => {
   const [viewedTab, setViewedTab] = useState<number>(0);
   const isActive = (index: number): boolean => index === viewedTab;
@@ -20,11 +19,10 @@ export const TabContainer: React.FC<TabContainerProps> = ({ tabs }) => {
           <div
             data-index={index}
             key={`${label}_tab`}
-            className={
-              cn(styles.tabs__tab, {
-                [styles.tabs__tab_active]: isActive(index)
-              })
-            }
+            tabIndex={0}
+            className={cn(styles.tabs__tab, {
+              [styles.tabs__tab_active]: isActive(index),
+            })}
             onClick={handleTabClick(index)}
           >
             {label}


### PR DESCRIPTION
add focus state on tabs in storybook

## Pull Request

### Description
<img width="556" alt="Screenshot 2022-09-07 at 11 08 02" src="https://user-images.githubusercontent.com/1616251/194310408-487ea7ab-7fb0-4db4-9471-818e2e40c774.png">

For accessibility storybook tabs should have a pressed state

The storybook tabs currently have a hover state, but need a focus state to give feedback to keyboard users so they can understand where they are in the page.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [x] `npm i` – for new NPM dependencies.
- [x] `npm run lint` - to check for linting issues
- [x] `npm run test` - to run unit tests
- [x] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
