### PR TITLE
docs(typography): remove references to highlighted prop

### DIFF
--- a/packages/typography/src/docs/Description.mdx
+++ b/packages/typography/src/docs/Description.mdx
@@ -5,7 +5,7 @@ The **Typography** component is used to display any types of text present on the
 In the design prototypes, when clicking on text, you will find a variant name like `h1`, `subheading2`, `body4`. That's all that you need to get your text component ready.
 Each variant contains already the expected font size, font weight, letter spacing, line height, and text transform.
 
-If you need to highlight a text, simply include the prop `highlighted`. In case you want to change the HTML tag the text should be wrapped, you can set a new one with `Component`. Feel free to include customized styles with `className`.
+In case you want to change the HTML tag the text should be wrapped, you can set a new one with `Component`. Feel free to include customized styles with `className`.
 
 ```tsx
 <Typography variant="h1">
@@ -13,11 +13,11 @@ If you need to highlight a text, simply include the prop `highlighted`. In case 
 </Typography>
 
 <Typography variant="caption2">
-  Your highlighted caption here!
+  Your caption here!
 </Typography>
 
 <Typography variant="body2" Component="span">
-  Your highlighted body text wrapped in `span` here!
+  Your body text wrapped in `span` here!
 </Typography>
 ```
 
@@ -46,10 +46,7 @@ render(
     <br />
     <br />
     <Typography variant="body5" Component="span">
-      Your body text wrapped in `span` here,
-      <Typography variant="body5" highlighted Component="span">
-        ⚠️ followed by some highlighted text.
-      </Typography>
+      Your body text wrapped in `span` here,⚠️followed by some more text.
     </Typography>
   </Container>,
 );


### PR DESCRIPTION
## Pull Request

### Description

Small update in the documentation, typography `highlighted` prop seems to have been removed at some point.

### Type of change

- [X] Documentation change