### PR TITLE
Fix `Badge` height

### DIFF
--- a/packages/badge/src/styles/default.module.css
+++ b/packages/badge/src/styles/default.module.css
@@ -19,6 +19,7 @@
   text-decoration: none;
   border-style: solid;
   font-weight: 500;
+  height: 28px;
 }
 
 .leftIcon {

--- a/packages/badge/src/styles/default.module.css
+++ b/packages/badge/src/styles/default.module.css
@@ -19,7 +19,7 @@
   text-decoration: none;
   border-style: solid;
   font-weight: 500;
-  height: 28px;
+  line-height: 20px;
 }
 
 .leftIcon {


### PR DESCRIPTION
## Pull Request

### Description

This PR fixes the Badge style mismatch with the provided [Figma](https://www.figma.com/file/rrvkvQEoVTOHa7MzyKSaoz/OTP-Global-Design-System?node-id=4031%3A102387)
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- The new height of the badge should be 28px

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
