### PR TITLE
feat(gaps): add 72px spacing to spacing variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54919,7 +54919,7 @@
     },
     "packages/form-control": {
       "name": "@heycar-uikit/form-control",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -54952,10 +54952,10 @@
     },
     "packages/input": {
       "name": "@heycar-uikit/input",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "UNLICENSED",
       "dependencies": {
-        "@heycar-uikit/form-control": "^1.5.0",
+        "@heycar-uikit/form-control": "^1.5.1",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -54980,7 +54980,7 @@
     },
     "packages/switch": {
       "name": "@heycar-uikit/switch",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -54991,10 +54991,10 @@
     },
     "packages/textarea": {
       "name": "@heycar-uikit/textarea",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@heycar-uikit/form-control": "^1.5.0",
+        "@heycar-uikit/form-control": "^1.5.1",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -56571,7 +56571,7 @@
     "@heycar-uikit/input": {
       "version": "file:packages/input",
       "requires": {
-        "@heycar-uikit/form-control": "^1.5.0",
+        "@heycar-uikit/form-control": "^1.5.1",
         "classnames": "^2.3.1"
       }
     },
@@ -56592,7 +56592,7 @@
     "@heycar-uikit/textarea": {
       "version": "file:packages/textarea",
       "requires": {
-        "@heycar-uikit/form-control": "^1.5.0",
+        "@heycar-uikit/form-control": "^1.5.1",
         "classnames": "^2.3.1"
       }
     },

--- a/packages/vars/src/gaps.css
+++ b/packages/vars/src/gaps.css
@@ -16,4 +16,5 @@
   --gap-7xl: 48px;
   --gap-8xl: 56px;
   --gap-9xl: 64px;
+  --gap-10xl: 72px;
 }


### PR DESCRIPTION
[MTEC-2610
](https://heycar.atlassian.net/browse/MTEC-2610)

## Pull Request

### Description

Added a new spacing variable `--gap-10xl` which corresponds to 72px.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [x] `npm i` – for new NPM dependencies.
- [x] `npm run lint` - to check for linting issues
- [x] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
