### PR TITLE
fix `Invalid DOM property`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54952,7 +54952,7 @@
     },
     "packages/input": {
       "name": "@heycar-uikit/input",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "UNLICENSED",
       "dependencies": {
         "@heycar-uikit/form-control": "^1.5.1",
@@ -54980,7 +54980,7 @@
     },
     "packages/switch": {
       "name": "@heycar-uikit/switch",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -55019,7 +55019,7 @@
     },
     "packages/vars": {
       "name": "@heycar-uikit/vars",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "UNLICENSED"
     }
   },

--- a/packages/icons/src/paths/ShoppingBag.tsx
+++ b/packages/icons/src/paths/ShoppingBag.tsx
@@ -4,8 +4,8 @@ import createSvgIcon from '../utils/createSvgIcon';
 
 export const ShoppingBag = createSvgIcon(
   <path
-    fill-rule="evenodd"
-    clip-rule="evenodd"
+    fillRule="evenodd"
+    clipRule="evenodd"
     d="M5.15363 19L5.85733 9.5L18.1427 9.5L18.8464 19L5.15363 19ZM16.9753 7.5L20 7.5L20.8519 19L21 21L18.9945 21L5.00548 21L3 21L3.14815 19L4 7.5L7.02469 7.5C7.27555 4.97334 9.40733 3 12 3C14.5927 3 16.7245 4.97334 16.9753 7.5ZM14.9585 7.5C14.7205 6.08114 13.4865 5 12 5C10.5135 5 9.27952 6.08114 9.04148 7.5L14.9585 7.5Z"
     fill="#303030"
   />,


### PR DESCRIPTION
## Pull Request

This PR fixes a console warning we get in FR regarding invalid DOM properties (the icon uses original SVG format that was not converted to JSX).

<img width="720" alt="Screen Shot 2022-12-01 at 16 36 08 " src="https://user-images.githubusercontent.com/236774/205094466-b42eebae-dd41-43cb-a7fd-348ee2c56ae9.png">

### Description

convert the properties so they are valid in JSX

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
