### PR TITLE
docs(styleguide convention): Remove recommendation to not use arrow functions

### DIFF
--- a/STYLEGUIDE_CONVENTION.md
+++ b/STYLEGUIDE_CONVENTION.md
@@ -10,7 +10,7 @@
 
 ### JSX
 
-Prefer normal functions (non arrow functions or classes):
+Prefer functions (not classes):
 
 ```JSX
 // bad
@@ -20,7 +20,7 @@ class Listing extends React.Component {
   }
 }
 
-// bad (relying on function name inference is discouraged)
+// good, but relying on function name inference is discouraged
 const Listing = ({ hello }) => (
   <div>{hello}</div>
 );


### PR DESCRIPTION
This is to remove the disencouragement to use arrow function from style conventions.

## Pull Request

### Description



### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
