### PR TITLE
docs: fix for icons now showing in docs

### DIFF
--- a/.storybook/scope.ts
+++ b/.storybook/scope.ts
@@ -3,6 +3,7 @@ import * as knobs from '@storybook/addon-knobs';
 import * as dateUtils from 'date-fns';
 
 import * as grid from './blocks/Grid';
+import * as AllIcons from '../packages/icons/src';
 
 const componentsContext = require.context(
   '../packages',
@@ -31,4 +32,5 @@ export default {
   ...grid,
   ...dateUtils,
   ...knobs,
+  ...AllIcons,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -54381,10 +54381,10 @@
     },
     "packages/accordion": {
       "name": "@heycar-uikit/accordion",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "UNLICENSED",
       "dependencies": {
-        "@heycar-uikit/collapse": "^1.4.0",
+        "@heycar-uikit/collapse": "^1.4.1",
         "@heycar-uikit/icons": "^4.0.0",
         "classnames": "^2.3.1"
       },
@@ -54405,7 +54405,7 @@
     },
     "packages/button": {
       "name": "@heycar-uikit/button",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -54428,7 +54428,7 @@
     },
     "packages/collapse": {
       "name": "@heycar-uikit/collapse",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -54439,7 +54439,7 @@
     },
     "packages/dropdown": {
       "name": "@heycar-uikit/dropdown",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@heycar-uikit/icons": "^4.0.0",
@@ -54513,11 +54513,11 @@
     },
     "packages/pagination": {
       "name": "@heycar-uikit/pagination",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@heycar-uikit/icons": "^3.0.1",
-        "@heycar-uikit/typography": "^3.2.0",
+        "@heycar-uikit/typography": "^3.3.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -54568,12 +54568,12 @@
     },
     "packages/themes": {
       "name": "@heycar-uikit/themes",
-      "version": "2.0.1",
+      "version": "2.2.0",
       "license": "UNLICENSED"
     },
     "packages/typography": {
       "name": "@heycar-uikit/typography",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "UNLICENSED",
       "dependencies": {
         "classnames": "^2.3.1"
@@ -54584,7 +54584,7 @@
     },
     "packages/vars": {
       "name": "@heycar-uikit/vars",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "UNLICENSED"
     }
   },
@@ -56081,7 +56081,7 @@
     "@heycar-uikit/accordion": {
       "version": "file:packages/accordion",
       "requires": {
-        "@heycar-uikit/collapse": "^1.4.0",
+        "@heycar-uikit/collapse": "^1.4.1",
         "@heycar-uikit/icons": "^4.0.0",
         "classnames": "^2.3.1"
       }
@@ -56156,7 +56156,7 @@
       "version": "file:packages/pagination",
       "requires": {
         "@heycar-uikit/icons": "^3.0.1",
-        "@heycar-uikit/typography": "^3.2.0",
+        "@heycar-uikit/typography": "^3.3.0",
         "classnames": "^2.3.1"
       },
       "dependencies": {


### PR DESCRIPTION
## Pull Request

### Description

icons used inside the live code blocks were having several of there props including className stripped. This was causing them to be rendered with 0 width and height

HEYUI-258

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
