### PR TITLE
fix(typography): remove classnames dependancy

### DIFF
--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -29,9 +29,7 @@
   "peerDependencies": {
     "react": "^17.0.1"
   },
-  "dependencies": {
-    "classnames": "^2.3.1"
-  },
+  "dependencies": {},
   "author": "HeyCar Team",
   "license": "UNLICENSED"
 }

--- a/packages/typography/src/Typography.tsx
+++ b/packages/typography/src/Typography.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import cn from 'classnames';
 
 import { defaultVariantMapping } from './Typography.constants';
 import { TypographyProps } from './Typography.types';
@@ -14,7 +13,9 @@ export const Typography: React.FC<TypographyProps> = ({
   dataTestId,
   ...restProps
 }) => {
-  const classNames = cn(styles.typography, styles[variant], className);
+  const classNames = `${styles.typography} ${styles[variant]} ${
+    className || ''
+  }`;
 
   return (
     <Component className={classNames} data-test-id={dataTestId} {...restProps}>


### PR DESCRIPTION
## Pull Request

### Description

classnames package is clashing with new build method

HEYUI-325

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
