### PR TITLE
fix(segmentedbuttons): less strict typing for buttons data + exported…

### DIFF
--- a/packages/segmented-buttons/src/SegmentedButtons.types.ts
+++ b/packages/segmented-buttons/src/SegmentedButtons.types.ts
@@ -23,15 +23,11 @@ interface ButtonProps {
   dataTestId?: string;
 }
 
-type Buttons =
-  | [ButtonProps, ButtonProps]
-  | [ButtonProps, ButtonProps, ButtonProps];
-
 interface ComponentProps {
   /**
    * An array of 2 or 3 buttons to display
    */
-  buttons: Buttons;
+  buttons: ButtonProps[];
   /**
    * The id for testing
    */
@@ -52,4 +48,4 @@ interface ComponentProps {
 
 type SegmentedButtonsProps = ComponentProps & HTMLAttributes<HTMLDivElement>;
 
-export { ButtonProps, Buttons, ComponentProps, SegmentedButtonsProps };
+export { ButtonProps, ComponentProps, SegmentedButtonsProps };

--- a/packages/segmented-buttons/src/__tests__/SegmentedButtons.mocks.ts
+++ b/packages/segmented-buttons/src/__tests__/SegmentedButtons.mocks.ts
@@ -1,6 +1,6 @@
-import { Buttons } from '../SegmentedButtons.types';
+import { ButtonProps } from '../SegmentedButtons.types';
 
-const BTN_DATA: Buttons = [
+const BTN_DATA: ButtonProps[] = [
   {
     label: 'Left',
     value: 'lft',
@@ -21,7 +21,7 @@ const BTN_DATA: Buttons = [
   },
 ];
 
-const TWO_BTNS: Buttons = [
+const TWO_BTNS: ButtonProps[] = [
   {
     label: 'Left',
     value: 'lft',
@@ -39,7 +39,7 @@ const TWO_BTNS: Buttons = [
 ];
 
 const modifyBtns = (isDisabled: boolean, icon: React.ReactNode | undefined) => {
-  const output: Buttons = [...BTN_DATA];
+  const output = [...BTN_DATA];
 
   output[0].isDisabled = isDisabled;
   output[1].isDisabled = isDisabled;

--- a/packages/segmented-buttons/src/index.ts
+++ b/packages/segmented-buttons/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SegmentedButtons';
+export { ButtonProps } from './SegmentedButtons.types';


### PR DESCRIPTION
## Pull Request

### Description

less strict typing for buttons data + exported ButtonProp type

HEYUI-370

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change

### How do I test this

- Add steps to test
- in bullet point format
- preferably you can add link to the storybook build in the PR

## Checklist

### Did you remember to take care of the following?

- [ ] `npm i` – for new NPM dependencies.
- [ ] `npm run lint` - to check for linting issues
- [ ] `npm run test` - to run unit tests
- [ ] `npm run test:sh:docker` - to run screenshot tests, [detail instruction](https://hey-car.github.io/heycar-uikit/main/?path=/docs/guidelines-screenshot-testing--page)

### New Feature / Bug Fix

- [ ] Run unit tests to ensure all existing tests are still passing.
- [ ] Add new passing unit tests to cover the code introduced by your pr.

Thanks for contributing!
